### PR TITLE
Fixed deprecated usage of `punkt`

### DIFF
--- a/diffir/weight/unsupervised.py
+++ b/diffir/weight/unsupervised.py
@@ -23,9 +23,9 @@ class ExactMatchWeight(Weight):
         :return:
         """
         try:
-            nltk.data.find("tokenizers/punkt")
+            nltk.data.find("tokenizers/punkt_tab")
         except (LookupError, OSError):
-            nltk.download("punkt")
+            nltk.download("punkt_tab")
         try:
             nltk.data.find("corpora/stopwords")
         except LookupError:
@@ -65,9 +65,9 @@ class ExactMatchWeight(Weight):
             return self.fast_score_document_regions(query, doc)
 
         try:
-            nltk.data.find("tokenizers/punkt")
+            nltk.data.find("tokenizers/punkt_tab")
         except (LookupError, OSError):
-            nltk.download("punkt")
+            nltk.download("punkt_tab")
         try:
             nltk.data.find("corpora/stopwords")
         except LookupError:

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-nltk>=3.5
+nltk>=3.8.2,==3.8.*
 ir_measures>=0.1.4
 mako~=1.1
 ir_datasets>=0.3.1


### PR DESCRIPTION
NLTK v3.8.2 has replaced the deprecated `punkt` with `punkt_tab`: https://github.com/nltk/nltk/issues/3293